### PR TITLE
fix: error http status code returns

### DIFF
--- a/src/auth/auth.service.js
+++ b/src/auth/auth.service.js
@@ -11,7 +11,7 @@ async function register(req, res) {
     const message = await controller.registerPlayer(name, login, password);
     res.status(CREATED).send({ message });
   } catch (err) {
-    res.status(500).send({ message: err.message });
+    res.status(err.httpStatus ?? 500).send({ message: err.message });
   }
 }
 
@@ -28,7 +28,7 @@ async function access(req, res) {
       res.status(OK).send({ message: 'Login successful' });
     });
   } catch (err) {
-    res.status(500).send({ message: err.message });
+    res.status(err.httpStatus ?? 500).send({ message: err.message });
   }
 }
 

--- a/src/inventory/inventory.service.js
+++ b/src/inventory/inventory.service.js
@@ -9,7 +9,7 @@ async function listAllItemsFromPlayer(req, res) {
     const playerItems = await controller.findAllItemsFromPlayer(player.uuid);
     res.status(OK).send(playerItems);
   } catch (err) {
-    res.status(500).send({ message: err.message });
+    res.status(err.httpStatus ?? 500).send({ message: err.message });
   }
 }
 
@@ -19,7 +19,7 @@ async function getItemDetails(req, res) {
     const item = await controller.getItemById(req.params.itemId, playerId);
     res.status(OK).send(item);
   } catch (err) {
-    res.status(500).send({ message: err.message });
+    res.status(err.httpStatus ?? 500).send({ message: err.message });
   }
 }
 
@@ -30,7 +30,7 @@ async function sellItemFromPlayer(req, res) {
     const message = await controller.sellItem(item, player.uuid);
     res.status(OK).send({ message });
   } catch (err) {
-    res.status(500).send({ message: err.message });
+    res.status(err.httpStatus ?? 500).send({ message: err.message });
   }
 }
 

--- a/src/player/player.service.js
+++ b/src/player/player.service.js
@@ -8,7 +8,7 @@ async function getPlayerInfo(req, res) {
     const profile = await controller.getPlayerProfile(playerId);
     res.status(OK).send(profile);
   } catch (err) {
-    res.status(500).send({ message: err.message });
+    res.status(err.httpStatus ?? 500).send({ message: err.message });
   }
 }
 
@@ -19,7 +19,7 @@ async function editPlayerInfo(req, res) {
     const message = await controller.editPlayer(player, name, password);
     res.status(OK).send({ message });
   } catch (err) {
-    res.status(500).send({ message: err.message });
+    res.status(err.httpStatus ?? 500).send({ message: err.message });
   }
 }
 
@@ -30,7 +30,7 @@ async function depositFunds(req, res) {
     const message = await controller.addFundsTo(player, depositQuantity);
     res.status(OK).send({ message });
   } catch (err) {
-    res.status(500).send({ message: err.message });
+    res.status(err.httpStatus ?? 500).send({ message: err.message });
   }
 }
 

--- a/src/trade/trade.service.js
+++ b/src/trade/trade.service.js
@@ -14,7 +14,7 @@ async function sendTradeOffer(req, res) {
     await controller.placeTradeOffer(tradeOffer);
     res.status(CREATED).send(tradeOffer);
   } catch (err) {
-    res.status(err.httpStatus).send({ message: err.message });
+    res.status(err.httpStatus ?? 500).send({ message: err.message });
   }
 }
 
@@ -25,7 +25,7 @@ async function acceptTradeOffer(req, res) {
     await controller.acceptTradeOffer(trade, player.uuid);
     res.status(OK).send({ ...trade, status: TradeStatus.ACCEPTED });
   } catch (err) {
-    res.status(err.httpStatus).send({ message: err.message });
+    res.status(err.httpStatus ?? 500).send({ message: err.message });
   }
 }
 
@@ -36,7 +36,7 @@ async function declineTradeOffer(req, res) {
     await controller.declineTradeOffer(trade, player.uuid);
     res.status(OK).send({ ...trade, status: TradeStatus.RECUSED });
   } catch (err) {
-    res.status(err.httpStatus).send({ message: err.message });
+    res.status(err.httpStatus ?? 500).send({ message: err.message });
   }
 }
 
@@ -46,7 +46,7 @@ async function listAllTradeOffersFromPlayer(req, res) {
     const playerTrades = await controller.findAllTradesFromPlayer(player.uuid);
     res.status(OK).send(playerTrades);
   } catch (err) {
-    res.status(500).send({ message: err.message });
+    res.status(err.httpStatus ?? 500).send({ message: err.message });
   }
 }
 
@@ -57,7 +57,7 @@ async function cancelTradeOffer(req, res) {
     await controller.cancelTradeOffer(trade, player.uuid);
     res.status(OK).send({ ...trade, status: TradeStatus.CANCELED });
   } catch (err) {
-    res.status(err.httpStatus).send({ message: err.message });
+    res.status(err.httpStatus ?? 500).send({ message: err.message });
   }
 }
 


### PR DESCRIPTION
This pr fixes all error returns, as it was the api only replied with 500 or tried to respond with err.httpStatus, 

but using only 500 we lose the benefits of using correct return codes, and by using only err.httpStatus, if the error was not a custom one the api would throw a new error and go offline

so i added err.httpStatus ?? 500, so if a custom error it will give the appropriate code and if it's not iw will return 500