### PR TITLE
fix: delete old images

### DIFF
--- a/src/middleware/imageUpload.js
+++ b/src/middleware/imageUpload.js
@@ -7,7 +7,7 @@ const storage = multer.diskStorage({
     cb(null, path.join(__dirname, '../uploads')); // Specify the folder where you want to save the images
   },
   filename: (req, file, cb) => {
-    cb(null, `${Date.now()}-${file.originalname}`); // Generate a unique filename
+    cb(null, `${req.player.login}.${file.mimetype.split('/')[1]}`); // Generate a unique filename
   },
 });
 


### PR DESCRIPTION
fix #40 

makes player profile picture have player login in it's name, like "falcao.png", so whenever a new picture is uploaded, the old one is replaced